### PR TITLE
Fix: XamlStyler.Console.csproj 3.2501.8 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm install
 
       - name: Build XamlStyler tool
-        run: dotnet publish -p:RollForward=Major -o ./tools/xstyler ./tools/XamlStyler/src/XamlStyler.Console
+        run: dotnet publish -f net8.0 -p:RollForward=Major -o ./tools/xstyler ./tools/XamlStyler/src/XamlStyler.Console
 
       - name: Remove unnecessary files
         run: find ./tools/xstyler -type f \( -name '*.pdb' -o -name '*.exe' -o -name '*.deps.json' \) -delete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Added
 - Also support .axml files ([AvaloniaTeam.vscode-avalonia](https://marketplace.visualstudio.com/items?itemName=AvaloniaTeam.vscode-avalonia) does note that extension for the AXAML language)
 
+## Changed
+- Bump XamlStyler.Console tool to 3.2501.8
+
 ## [1.0.0]
 ### Changed
 - First non-pre-release of the extension


### PR DESCRIPTION
The reason is, that XamlStyler.Console.csproj changed its element from TargetFramework to TargetFrameworks which lets the publish command assume that it is a cross target build.

References:
- https://github.com/dabbinavo/vscode-xamlstyler/actions/runs/13685140763/job/38266699237https://github.com/dabbinavo/vscode-xamlstyler/actions/runs/13685140763/job/38266699237
- https://github.com/dotnet/sdk/issues/30251