### PR TITLE
feat(lang): enable formatting with axaml language

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "activationEvents": [
     "onLanguage:xml",
     "onLanguage:AXAML",
-    "onLanguage:xaml"
+    "onLanguage:xaml",
+    "onLanguage:axaml"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/src/common.ts
+++ b/src/common.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 /**
  * Keep the {@link languages} in sync with {@link file://./../package.json} > activationEvents
  */
-const languages = ["xaml", "AXAML", "xml"]; 
+const languages = ["xaml", "AXAML", "xml", "axaml"]; 
 
 const xamlPattern = "**/*.{xaml,axaml,axml}";
 


### PR DESCRIPTION
The [VS Code Tools for AXAML by LeXtudio Inc.](https://marketplace.visualstudio.com/items?itemName=lextudio.vscode-axaml) extension uses the axaml (not AXAML) language mode. 
This PR adds support for axaml language mode.

